### PR TITLE
Update documentation to use router.urls attribute

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,11 +65,11 @@ In your `urls.py` add the following URL route to enable obtaining a token via a 
 Configure your urls to add new endpoint
 
 ```python
-from refreshtoken.routers import urlpatterns as rt_urlpatterns
+from refreshtoken.routers import router as rt_router
 
 urlpatterns = [
     url(...),
-] + rt_urlpatterns
+] + rt_router.urls
 
 ```
 


### PR DESCRIPTION
I noticed that the docs were referencing a variable that doesn't exist anymore, so I figured I would update it.

On a side note, I noticed there are references to a `/delegate` endpoint in other parts of the README and in the tests. Perhaps it would be worthwhile to add that in this section as well? Let me know and I can true that up.