### PR TITLE
Improve security

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,3 +109,9 @@ $ http POST client_id=app grant_type="urn:ietf:params:oauth:grant-type:jwt-beare
 ```json
 {"token": "your_jwt_token_...", "refresh_token": "your long running refresh token..."}
 ```
+
+Like `django-rest-framework-jwt`, It's also possible to pass the `REFRESH_TOKEN` as a cookie. It's recommended to use a Secure/httpOnly cookie so the cookie value can't be read from JavaScript.
+
+If you set `JWT_AUTH_COOKIE` `django-rest-framework-jwt-refresh-token` automatically does that for you.
+
+***Note that the cookies are checked before the request body.***

--- a/refreshtoken/authentication.py
+++ b/refreshtoken/authentication.py
@@ -11,6 +11,12 @@ from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 
 def jwt_decode_handler(token):
+    """
+    Disable token signature verification.
+
+    This allows us to verify expired tokens without getting a
+    jwt.InvalidToken exception.
+    """
     options = {
         'verify_exp': False
     }
@@ -33,17 +39,19 @@ class RefreshTokenAuthentication(JSONWebTokenAuthentication):
     """
     Extends JSONWebTokenAuthentication to:
 
-    Allow users to authenticate with expired JWT's
+    Allow users authenticate with expired JWT's
     """
 
     def get_jwt_value(self, request):
-        """Get signed cookie."""
+        """Get the JWT from the signed cookie or request header."""
         auth = get_authorization_header(request).split()
         auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
 
         if not auth:
             if api_settings.JWT_AUTH_COOKIE:
-                return request.get_signed_cookie(api_settings.JWT_AUTH_COOKIE, default=None)
+                return request.get_signed_cookie(
+                    api_settings.JWT_AUTH_COOKIE, default=None
+                )
             return None
 
         if smart_text(auth[0].lower()) != auth_header_prefix:

--- a/refreshtoken/authentication.py
+++ b/refreshtoken/authentication.py
@@ -1,0 +1,107 @@
+from django.utils.encoding import smart_text
+from django.contrib.auth import get_user_model
+from django.utils.translation import ugettext as _
+
+import jwt
+from rest_framework import exceptions
+from rest_framework_jwt.settings import api_settings
+from rest_framework_jwt.utils import jwt_get_secret_key
+from rest_framework.authentication import get_authorization_header
+from rest_framework_jwt.authentication import JSONWebTokenAuthentication
+
+
+def jwt_decode_handler(token):
+    options = {
+        'verify_exp': False
+    }
+    # get user from token, BEFORE verification, to get user secret key
+    unverified_payload = jwt.decode(token, None, False)
+    secret_key = jwt_get_secret_key(unverified_payload)
+    return jwt.decode(
+        token,
+        api_settings.JWT_PUBLIC_KEY or secret_key,
+        api_settings.JWT_VERIFY,
+        options=options,
+        leeway=api_settings.JWT_LEEWAY,
+        audience=api_settings.JWT_AUDIENCE,
+        issuer=api_settings.JWT_ISSUER,
+        algorithms=[api_settings.JWT_ALGORITHM]
+    )
+
+
+class RefreshTokenAuthentication(JSONWebTokenAuthentication):
+    """
+    Extends JSONWebTokenAuthentication to:
+
+    Allow users to authenticate with expired JWT's
+    """
+
+    def get_jwt_value(self, request):
+        """Get signed cookie."""
+        auth = get_authorization_header(request).split()
+        auth_header_prefix = api_settings.JWT_AUTH_HEADER_PREFIX.lower()
+
+        if not auth:
+            if api_settings.JWT_AUTH_COOKIE:
+                return request.get_signed_cookie(api_settings.JWT_AUTH_COOKIE, default=None)
+            return None
+
+        if smart_text(auth[0].lower()) != auth_header_prefix:
+            return None
+
+        if len(auth) == 1:
+            msg = _('Invalid Authorization header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid Authorization header. Credentials string '
+                    'should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth[1]
+
+    def authenticate(self, request):
+        """
+        Returns a two-tuple of `User` and token if a valid signature has been
+        supplied using JWT-based authentication.  Otherwise returns `None`.
+        """
+        jwt_value = self.get_jwt_value(request)
+        if jwt_value is None:
+            return None
+
+        try:
+            payload = jwt_decode_handler(jwt_value)
+        except jwt.DecodeError:
+            msg = _('Error decoding signature.')
+            raise exceptions.AuthenticationFailed(msg)
+        except jwt.InvalidTokenError:
+            raise exceptions.AuthenticationFailed()
+
+        user = self.authenticate_credentials(payload)
+
+        return user, payload
+
+    def jwt_get_user_uuid_from_payload(self, payload):
+        """Get the user's uuid from the JWT payload."""
+
+        return payload.get('uuid')
+
+    def authenticate_credentials(self, payload):
+        """Returns an active user that matches the JWT payload's user uuid."""
+        User = get_user_model()
+        user_uuid = self.jwt_get_user_uuid_from_payload(payload)
+
+        if not user_uuid:
+            msg = _('Invalid payload.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            user = User.objects.get(uuid=user_uuid)
+        except User.DoesNotExist:
+            msg = _('User Does not Exist.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        if not user.is_active:
+            msg = _('User account is disabled.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return user

--- a/refreshtoken/serializers.py
+++ b/refreshtoken/serializers.py
@@ -32,7 +32,7 @@ class RefreshTokenSerializer(serializers.ModelSerializer):
 
 
 class DelegateJSONWebTokenSerializer(serializers.Serializer):
-    client_id = serializers.CharField()
+    client_id = serializers.CharField(required=False)
     grant_type = serializers.CharField(
         default='urn:ietf:params:oauth:grant-type:jwt-bearer',
         required=False,

--- a/refreshtoken/settings.py
+++ b/refreshtoken/settings.py
@@ -1,0 +1,15 @@
+import datetime
+
+from django.conf import settings
+from rest_framework.settings import APISettings
+
+
+USER_SETTINGS = getattr(settings, 'JWT_AUTH', None)
+
+DEFAULTS = {
+    'JWT_APP_NAME': 'refreshtoken',
+    'JWT_REFRESH_COOKIE': 'refresh_token',
+    'JWT_REFRESH_COOKIE_EXPIRATION_DELTA': datetime.timedelta(seconds=300)
+}
+
+api_settings = APISettings(USER_SETTINGS, DEFAULTS, [])


### PR DESCRIPTION
First of all, Just like `django-rest-framework-jwt`, Users should have the options to store the token in a cookie.

 - Refresh Tokens should be stored securely, It's not enough to store it as a plain cookie because the token is essentially acts like the user's password. It should be stored in the safest place possible in the browser which is a `Secure/httpOnly cookie` where it can't be read/manipulated from JavaScript (`XSS` attacks), `CSRF` attacks can be prevented by setting the `samesite` property on the cookie. (This is something that we can look at later.)
   
 - Ensure that the user presents a token (expired or valid) token before granting them a new one. If a refreshtoken is leaked, the attacker must present a token (For authentication) alongside the refresh token before they receive a new token. This adds an extra layer of protection.
_Note it's not a standard, but I feel it's better to add an authentication layer to the `DelegateJSONWebToken` view. In my opinion it's better than leaving the `DelegateJSONWebToken` unprotected._
