### PR TITLE
bugfix for importerror in DRF>=3.8, detail_route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,19 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-django2.0-drf3.8-jwt1.11
       python: 3.6
+    - env: TOXENV=py36-django2.0-drf3.9-jwt1.11
+      python: 3.6
+    - env: TOXENV=py36-django2.0-drf3.10-jwt1.11
+      python: 3.6
     - env: TOXENV=py37-django2.1-drf3.8-jwt1.11
+      python: 3.7
+      dist: xenial
+      sudo: true
+    - env: TOXENV=py37-django2.1-drf3.9-jwt1.11
+      python: 3.7
+      dist: xenial
+      sudo: true
+    - env: TOXENV=py37-django2.1-drf3.10-jwt1.11
       python: 3.7
       dist: xenial
       sudo: true

--- a/refreshtoken/views.py
+++ b/refreshtoken/views.py
@@ -1,12 +1,18 @@
 from calendar import timegm
 from datetime import datetime
+from functools import partial
 
 from django.utils.translation import ugettext as _
 from rest_framework import exceptions, generics, status, viewsets
-from rest_framework.decorators import detail_route
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework_jwt.settings import api_settings
+try:
+    from rest_framework.decorators import detail_route
+except ImportError:
+    # DRF >= 3.8
+    from rest_framework.decorators import action
+    detail_route = partial(action, detail=True)
 
 from .models import RefreshToken
 from .serializers import DelegateJSONWebTokenSerializer, RefreshTokenSerializer

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
        flake8,docs
-       py{34,35,36}-django1.11-drf{3.6,3.7,3.8}-jwt1.11
-       py{34,35,36,37}-django2.0-drf{3.7,3.8}-jwt1.11
-       py{35,36,37}-django2.1-drf{3.7,3.8}-jwt1.11
+       py{34,35,36}-django1.11-drf{3.6,3.7,3.8,3.9,3.10}-jwt1.11
+       py{34,35,36,37}-django2.0-drf{3.7,3.8,3.9,3.10}-jwt1.11
+       py{35,36,37}-django2.1-drf{3.7,3.8,3.9,3.10}-jwt1.11
 
 [testenv]
 commands = pytest --cov=refreshtoken --cov-report=term-missing:skip-covered {posargs}
@@ -14,6 +14,8 @@ deps =
        drf3.6: djangorestframework>=3.6,<3.7
        drf3.7: djangorestframework>=3.7,<3.8
        drf3.8: djangorestframework>=3.8,<3.9
+       drf3.9: djangorestframework>=3.9,<3.10
+       drf3.10: djangorestframework>=3.10,<3.11
        jwt1.11: djangorestframework-jwt>=1.11,<1.12
        -rrequirements/dev.txt
 


### PR DESCRIPTION
fixes this error, caused by deprecation of this function in DjangoRestFramework

```
__________ ERROR collecting tests/test_long_refresh_token_views.py ___________
ImportError while importing test module '/home/work/dev/django-rest-framework-jwt-refresh-token/tests/test_long_refresh_token_views.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_long_refresh_token_views.py:8: in <module>
    from refreshtoken.views import RefreshTokenViewSet
refreshtoken/views.py:6: in <module>
    from rest_framework.decorators import detail_route
E   ImportError: cannot import name 'detail_route' from 'rest_framework.decorators' (/home/work/.pyenv/versions/3.7.4/envs/django-rest-framework-jwt-refresh-token/lib/python3.7/site-packages/rest_framework/decorators.py)
```